### PR TITLE
fix: update Articles health check to uncached url

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -18,7 +18,7 @@ sites:
       - patheard
       - dinophile
   - name: GC Articles - Articles GC
-    url: https://articles.alpha.canada.ca/
+    url: https://articles.alpha.canada.ca/sign-in-se-connecter/
     assignees:
       - maxneuvians
       - CalvinRodo


### PR DESCRIPTION
# Summary
Update the GC Articles health check to a url that is not cached by CloudFront.
This will allow us to catch downtime more quickly.

# Related
* cds-snc/gc-articles#1031