### PR TITLE
docs: add site onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ With [Upptime](https://upptime.js.org), you can get your own unlimited and free 
 
 ## Onboarding
 
-To add a new site, update the `sites` key in [.upptimerc.yml](https://github.com/cds-snc/status-statut/blob/main/.upptimerc.yml#L5) with a new site:
+To add a new site update the `sites` key in [.upptimerc.yml](https://github.com/cds-snc/status-statut/blob/main/.upptimerc.yml#L5) with a new entry:
 ```yaml
-  - name: Site name
-    url: https://your-sites-url.ca
+  - name: Your site name
+    url: https://your-site-url.ca
     assignees:
       - github-username-to-notify
       - another-github-username-to-notify      

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ With [Upptime](https://upptime.js.org), you can get your own unlimited and free 
 
 [**Visit our status website →**](https://cds-snc.github.io/status-statut)
 
+## Onboarding
+
+To add a new site, update the `sites` key in [.upptimerc.yml](https://github.com/cds-snc/status-statut/blob/main/.upptimerc.yml#L5) with a new site:
+```yaml
+  - name: Site name
+    url: https://your-sites-url.ca
+    assignees:
+      - github-username-to-notify
+      - another-github-username-to-notify      
+```
+
 ## 📄 License
 
 - Powered by: [Upptime](https://github.com/upptime/upptime)


### PR DESCRIPTION
# Summary
Add a guide for onboarding new sites:
https://github.com/cds-snc/status-statut/blob/docs/onboarding/README.md#onboarding