### PR TITLE
Adding Learning resources website to the CDS status page.

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -73,6 +73,15 @@ sites:
       - CalvinRodo
       - patheard
       - dinophile
+  - name: Learning Resources 
+    url: https://learning-resources.cdssandbox.xyz/ 
+    assignees:
+      - maxneuvians
+      - CalvinRodo
+      - patheard
+      - dinophile
+      - daine
+      - dylanzheng94
 
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain


### PR DESCRIPTION
# Summary | Résumé

Modifying .upptimerc.yml file to add learning resources to the Status page. 

# Test instructions | Instructions pour tester la modification
Verify that the learning resources page shows up on the CDS status page and that the appropriate history and settings are created. 
