### PR TITLE
chore: switch to ubuntu-latest runner

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Generate graphs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Check status
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   release:
     name: Setup Upptime
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Build and deploy site
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Generate README
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Check status
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0


### PR DESCRIPTION
# Summary
Ubuntu 18x runners are being deprecated.