### PR TITLE
fix: use workflow run's HTML url

### DIFF
--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - name: Notify Slack
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Status workflow failed: <${{ github.event.workflow.url }}|${{ github.event.workflow.name }}>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Status page workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.STATUS_OPS_WEBHOOK }}


### PR DESCRIPTION
# Summary
Update the Slack message's workflow run URL to use the link that sends people to the GitHub action run page.