### PR TITLE
chore: update URL Shortener status to prod

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -74,7 +74,7 @@ sites:
       - patheard
       - dinophile
   - name: URL Shortener
-    url: https://url-shortener.cdssandbox.xyz/healthcheck
+    url: https://o.alpha.canada.ca/healthcheck
     assignees:
       - maxneuvians
       - cgye


### PR DESCRIPTION
# Summary
Update the URL Shortener status check to use the production URL.