### PR TITLE
chore: remove Scan Websites

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -38,13 +38,6 @@ sites:
       - CalvinRodo
       - patheard
       - dinophile
-  - name: Scan websites
-    url: https://scan-websites.alpha.canada.ca/
-    assignees:
-      - maxneuvians
-      - CalvinRodo
-      - patheard
-      - dinophile
   - name: Scan files
     url: https://scan-files.alpha.canada.ca/healthcheck
     assignees:


### PR DESCRIPTION
# Summary
Remove the calls to invoke Scan Websites.  This has been replaced by https://github.com/cds-snc/automatic-website-scanning

# Related
- cds-snc/site-reliability-engineering#858