### PR TITLE
chore: update URL Shortener's healthcheck endpoint

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -67,7 +67,7 @@ sites:
       - patheard
       - dinophile
   - name: URL Shortener
-    url: https://o.alpha.canada.ca/healthcheck
+    url: https://o.alpha.canada.ca/version
     assignees:
       - maxneuvians
       - cgye


### PR DESCRIPTION
# Summary
Update to use the `/version` endpoint as the healthcheck.

# Related
- cds-snc/url-shortener#370