### PR TITLE
fix: upgrade to latest version of uptime action

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update response time
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -26,20 +26,20 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update template
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Update response time
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GITHUB_TOKEN }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "readme"
         env:
@@ -50,7 +50,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate site
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -26,7 +26,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate site
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "readme"
         env:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@d1a6f908eb8a4653993400838ea55415383f1657 # v1.29.0
+        uses: upptime/uptime-monitor@5b1a0e4262482a1710bb03d610192830862e700c # v1.30.1
         with:
           command: "update"
         env:


### PR DESCRIPTION
# Summary
Upgrade to the latest version of the uptime GitHub action. This contains a fix for the Node version compiled error:
```
Was compiled against a different Node.js version using
NODE_MODULE_VERSION 72. This version of Node.js requires
NODE_MODULE_VERSION 93.
```

# Related
- https://github.com/upptime/upptime/issues/800