### PR TITLE
chore: remove URL Shortener status check

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -66,13 +66,6 @@ sites:
       - CalvinRodo
       - patheard
       - dinophile
-  - name: URL Shortener
-    url: https://o.alpha.canada.ca/version
-    assignees:
-      - maxneuvians
-      - cgye
-      - patheard
-      - dinophile      
   - name: GitHub secret scanning
     url: https://github-secret-scanning.alpha.canada.ca/healthcheck
     assignees:


### PR DESCRIPTION
# Summary
Remove the status check on URL Shortener as the product is being shutdown.

# Related
- https://github.com/cds-snc/platform-core-services/issues/449