### PR TITLE
chore: remove healthcheck on Share Files

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -52,13 +52,6 @@ sites:
       - CalvinRodo
       - patheard
       - dinophile
-  - name: Share file securely
-    url: https://share-files.cdssandbox.xyz/healthcheck
-    assignees:
-      - maxneuvians
-      - CalvinRodo
-      - patheard
-      - dinophile
   - name: SRE Bot
     url: https://sre-bot.cdssandbox.xyz/version
     assignees:


### PR DESCRIPTION
# Summary
Update the health checks to remove Share Files as
the service is being shutdown.

# Related
- https://github.com/cds-snc/share-files-securely/pull/28