### PR TITLE
fix: temporarily disable Slack notification

### DIFF
--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -1,10 +1,7 @@
 name: Workflow failure
 
 on:
-  workflow_run:
-    workflows: ["*"]
-    types:
-      - completed
+  workflow_dispatch:
 
 jobs:
   on-failure:


### PR DESCRIPTION
# Summary
Disable the Slack notification while we look for a deprecated Node.js fix for the uptime action.
```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744, upptime/uptime-monitor@a2ff879ffd0ace540d1b14122b65366f0ac36e1c.
```