### PR TITLE
test: invalid URL to trigger notification

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -72,7 +72,11 @@ sites:
       - patheard
       - dinophile
       - sylviamclaughlin 
-      - gcharest 
+      - gcharest
+  - name: Payload Test
+    url: https://not-valid.cdssandbox.xyz/
+    assignees:
+      - gcharest
 
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain


### PR DESCRIPTION
# Summary | Résumé

This temporary site is going to be used to trigger downtime notifications. These notifications format can't be adjusted since they are handled by Upptime and their current model doesn't match the expected AWS SNS payload.

It will removed once we have tested the changes.