### PR TITLE
feat: add CodeBuild GitHub Runner for status checks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "status-statut",
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye@sha256:f485b76ec2971017849252b494e61f4b7d97cd75d094db8161c34343edc026e9",
+  "containerEnv": {
+    "SHELL": "/bin/zsh"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.10.5",
+      "terragrunt": "0.72.9"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "hashicorp.terraform",
+        "github.copilot",
+        "github.vscode-github-actions",
+        "hashicorp.hcl"
+      ]
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,42 @@
+name: "Terraform apply"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-apply.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  CONFTEST_VERSION: 0.27.0
+  TERRAFORM_VERSION: 1.10.5
+  TERRAGRUNT_VERSION: 0.72.9
+  TF_INPUT: false
+  TF_VAR_github_personal_access_token: ${{ secrets.CODEBUILD_RUNNER_PERSONAL_ACCESS_TOKEN }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::283582579564:role/status-statut-apply
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terragrunt apply
+        working-directory: "terraform"
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,48 @@
+name: "Terraform plan"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-plan.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  CONFTEST_VERSION: 0.27.0
+  TERRAFORM_VERSION: 1.10.5
+  TERRAGRUNT_VERSION: 0.72.9
+  TF_INPUT: false
+  TF_VAR_github_personal_access_token: ${{ secrets.CODEBUILD_RUNNER_PERSONAL_ACCESS_TOKEN }}
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform-plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::283582579564:role/status-statut-plan
+          role-session-name: TFPlan
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terragrunt plan
+        uses: cds-snc/terraform-plan@d79bcf0eccf632a0ad9e9193072b42c970766c5b # v3.3.1
+        with:
+          directory: "terraform"
+          comment-delete: "true"
+          comment-title: "Terraform: GitHub Runner :octocat:"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Terraform
+.terragrunt-cache
+.terraform
+*.tfstate
+*.tfvars

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.86.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:EUPkb4+kiun34GH38Y0MEzqcSXr4eUniBKjXsNmySeU=",
+    "zh:1587c6a0199dc33d066c13e1628bc0dd966d7d6740cb2007b636524a3ec99430",
+    "zh:15af46cc5bb43a37c24438cb3a36d44209a89d923ea4d4d631b56b1a89717b26",
+    "zh:166902101ac1cc8ec4f53e3bdcbab2eac7eb448b1c428c2e622adbf9ce1a679c",
+    "zh:284d116ac9d4a4de74cd1f52486f00e10bc400d9654f92a8990ea0093c43ff78",
+    "zh:4135e928f20d456172c8ab4ae3d4d8e411b6feddc94aaa1347c92469d52f1e61",
+    "zh:72b317d17182c3e0ee72f2851d25565d369cb6ee803b12adc9b6c6d3dbfca8d7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9dd0e80964e215ff658b708be72ccda8a20f63af7eaebdd6f11eb0461633bb03",
+    "zh:a18e502c16b7b6b216b888eab9a5c66b1ed103847fce6985850e4fc9e364a3e8",
+    "zh:c239f12648d7f7bbadbf5db0b57aaa9429abe70b574975b581784b4f17b7ed79",
+    "zh:c5164ca8254b9973ee985a3841a4b1f776844c7dcbc112ab3a88a0096e7e2198",
+    "zh:d93ac58092c3fffc5ddc688b39721fbfacc353e8965001060a5a1ce934d97246",
+    "zh:e877f1be2ebe67a2d163b7488f47cff4c95aca9c541ddfa25ad16c6ecc98f6a8",
+    "zh:eb71af6dfdd2b5670b5b957397a576d6053587c75750c17acc105fb44ed806eb",
+    "zh:ff6aa4f88f8e789375391bc8c886c636fb3e4a45a3fd7dc291bca17c2b8d4184",
+  ]
+}

--- a/terraform/codebuild.tf
+++ b/terraform/codebuild.tf
@@ -1,0 +1,9 @@
+module "github_runner" {
+  source = "github.com/cds-snc/terraform-modules//codebuild_github_runner?ref=v10.3.0"
+
+  project_name                 = "cds-snc-status-statut"
+  github_repository_url        = "https://github.com/cds-snc/status-statut.git"
+  github_personal_access_token = var.github_personal_access_token
+
+  billing_tag_value = "SRE"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -4,10 +4,10 @@ locals {
 
 terraform {
   source = "."
+}
 
-  inputs = {
-    region = local.region
-  }
+inputs = {
+  region = local.region
 }
 
 remote_state {

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -1,0 +1,26 @@
+locals {
+  region = "ca-central-1"
+}
+
+terraform {
+  source = "."
+
+  inputs = {
+    region = local.region
+  }
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    encrypt             = true
+    bucket              = "status-statut-tf"
+    use_lockfile        = true
+    region              = local.region
+    key                 = "./terraform.tfstate"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "github_personal_access_token" {
+  description = "The GitHub personal access token to use for the CodeBuild project"
+  type        = string
+  sensitive   = true
+}
+
+variable "region" {
+  description = "The AWS region to deploy to"
+  type        = string
+}


### PR DESCRIPTION
# Summary
Add Terraform to manage a CodeBuild project.  This project will provide a serverless GitHub runner for the Upptime status check workflow.

The goal is to have the status checks executing in AWS infrastructure as it is less likely that it will be blocked by the AWS WAF managed IP reputation rule group, which we're currently seeing the GitHub hosted runners in Azure.

# Related
- https://github.com/cds-snc/platform-core-services/issues/664