### PR TITLE
fix: add secret header for Superset requests

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -73,12 +73,16 @@ sites:
       - gcharest 
   - name: Superset
     url: https://superset.cds-snc.ca/healthcheck
+    headers:
+      - "Upptime: $SUPERSET_HEADER"
     assignees:
       - patheard
       - willeybryan
       - wmoussa-gc
   - name: Superset Docs
     url: https://docs.superset.cds-snc.ca
+    headers:
+      - "Upptime: $SUPERSET_HEADER"
     assignees:
       - patheard
       - willeybryan


### PR DESCRIPTION
# Summary
Superset has a Canada only geo restriction and although our custom runners are in ca-central-1, they are occasionally identified as being in the US.

Adding this secret header will allow those misidentified requests to pass through the WAF's geo restriction rule.

# Related
- https://github.com/cds-snc/cds-superset/pull/323
- https://github.com/cds-snc/cds-superset-docs/pull/41