### PR TITLE
feat: switch runner to CodeConnection

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -14,7 +14,6 @@ env:
   TERRAFORM_VERSION: 1.10.5
   TERRAGRUNT_VERSION: 0.72.9
   TF_INPUT: false
-  TF_VAR_github_personal_access_token: ${{ secrets.CODEBUILD_RUNNER_PERSONAL_ACCESS_TOKEN }}
 
 permissions:
   id-token: write

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -14,7 +14,6 @@ env:
   TERRAFORM_VERSION: 1.10.5
   TERRAGRUNT_VERSION: 0.72.9
   TF_INPUT: false
-  TF_VAR_github_personal_access_token: ${{ secrets.CODEBUILD_RUNNER_PERSONAL_ACCESS_TOKEN }}
 
 permissions:
   id-token: write

--- a/terraform/codebuild.tf
+++ b/terraform/codebuild.tf
@@ -1,9 +1,9 @@
 module "github_runner" {
-  source = "github.com/cds-snc/terraform-modules//codebuild_github_runner?ref=v10.10.2"
+  source = "github.com/cds-snc/terraform-modules//codebuild_github_runner?ref=v10.11.0"
 
-  project_name                 = "cds-snc-status-statut"
-  github_repository_url        = "https://github.com/cds-snc/status-statut.git"
-  github_personal_access_token = var.github_personal_access_token
+  project_name               = "cds-snc-status-statut"
+  github_repository_url      = "https://github.com/cds-snc/status-statut.git"
+  github_codeconnection_name = "cds-snc-status-statut"
 
   billing_tag_value = "SRE"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,3 @@
-variable "github_personal_access_token" {
-  description = "The GitHub personal access token to use for the CodeBuild project"
-  type        = string
-  sensitive   = true
-}
-
 variable "region" {
   description = "The AWS region to deploy to"
   type        = string


### PR DESCRIPTION
# Summary
Remove the GitHub PAT and switch to using a CodeConnection to authenticate CodeBuild with GitHub. The CodeConnection uses the AWS managed GitHub app that is installed in our org.

# Related
- https://github.com/cds-snc/terraform-modules/pull/795