### PR TITLE
Use a realistic user agent when running uptime checks

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -96,6 +96,8 @@ sites:
       - iamnvc
   - name: CanadaLogin Website FR 
     url: https://connexion.canada.ca
+    headers:
+      - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
     assignees:
       - MahamoudTBS
       - melodyhabb
@@ -105,6 +107,8 @@ sites:
       - obie-okongwu   
   - name: CanadaLogin Website EN
     url: https://login.canada.ca
+    headers:
+      - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
     assignees:
       - MahamoudTBS
       - melodyhabb
@@ -115,6 +119,8 @@ sites:
       - astaylordev
   - name: CanadaLogin Manage Profile [Staging]
     url: https://app.login-connexion.alpha.canada.ca
+    headers:
+      - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
     assignees:
       - MahamoudTBS
       - johnphan-cds
@@ -125,6 +131,8 @@ sites:
       - srtalbot
   - name: CanadaLogin Manage Profile [Prod]
     url: https://app.login-connexion.canada.ca
+    headers:
+      - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
     assignees:
       - MahamoudTBS
       - johnphan-cds
@@ -135,6 +143,8 @@ sites:
       - srtalbot
   - name: CanadaLogin IDP [Staging]
     url: https://auth.login-connexion.alpha.canada.ca
+    headers:
+      - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
     assignees:
       - MahamoudTBS
       - johnphan-cds
@@ -145,6 +155,8 @@ sites:
       - srtalbot
   - name: CanadaLogin IDP  [Prod]
     url: https://auth.login-connexion.canada.ca
+    headers:
+      - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
     assignees:
       - MahamoudTBS
       - johnphan-cds


### PR DESCRIPTION
# Summary | Résumé

[Our uptime monitor is failing due to 403s.](https://github.com/cds-snc/status-statut/issues/436) These are from our WAF rejecting the requests due to an unrealistic user agent:

<img width="391" height="134" alt="Screenshot 2026-04-27 at 12 00 35 PM" src="https://github.com/user-attachments/assets/84a6e0fd-a7a7-42fe-8f75-32964229e636" />

This PR sets a modern user agent that will hopefully fix the issue.

There is documentation for this config key [here](https://upptime.js.org/docs/configuration).

# Test instructions | Instructions pour tester la modification

The workflow has a `workflow_dispatch` trigger so we can trigger the workflow [here](https://github.com/cds-snc/status-statut/actions/workflows/uptime.yml) using the source code from this branch to see if this works as expected. I'd like a :+1: from someone who maintains the repo before doing so though.
