### PR TITLE
Add header to CanadaLogin static website requests to allow upptime to pass WAF

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -98,6 +98,7 @@ sites:
     url: https://connexion.canada.ca
     headers:
       - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
+      - "Upptime: $CANADALOGIN_HEADER"
     assignees:
       - MahamoudTBS
       - melodyhabb
@@ -109,6 +110,7 @@ sites:
     url: https://login.canada.ca
     headers:
       - "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
+      - "Upptime: $CANADALOGIN_HEADER"
     assignees:
       - MahamoudTBS
       - melodyhabb


### PR DESCRIPTION
# Summary | Résumé

This PR makes upptime provide a `upptime: <secret>` header to status check requests to our static website. Our static website has been configured to allow these requests through the waf in [this PR.](https://github.com/cds-snc/gc-signin-terraform/pull/424)

The secret has been set in the GitHub Actions secrets.

# Test instructions | Instructions pour tester la modification

CI ran and stated that our sites were online: https://github.com/cds-snc/status-statut/actions/runs/25386158011/job/74486496732#step:4:130

In our WAF dashboard I can see two requests were made that were allowed through by the Upptime WAF rule.

<img width="1425" height="192" alt="Screenshot 2026-05-05 at 3 19 23 PM" src="https://github.com/user-attachments/assets/fa6f5440-63e8-4637-9add-d2c60ecb43d9" />
